### PR TITLE
Remove hardcoded loopback fallback token in Web Clipboard

### DIFF
--- a/body.txt
+++ b/body.txt
@@ -1,0 +1,16 @@
+Follow-up to the issue I opened — figured a PR would save you a round trip, feel free to close/redo if you want it done differently.
+
+This removes `FALLBACK_TOKEN` from `ClipboardSyncLoopbackAuth` and everywhere it was accepted as a stand-in for the real per-install random loopback token. Right now `isLoopbackIngressAuthorized()` in `ClipboardSyncWebPortal` treats the hardcoded string `"gboardpatches-web-clipboard-loopback-fallback-v1"` as valid auth for `POST /phone-clipboard`, which is also the one endpoint that skips the pairing-code check for loopback callers. Since that string is sitting in the public repo (and just as easy to pull out of the built APK), any other app on the device can hit `127.0.0.1:<port>/phone-clipboard` with that header and get treated as a trusted local client, no matter what the actual random token is. Loopback sockets aren't permission-gated on Android so this doesn't take anything beyond normal INTERNET access to pull off.
+
+What changed:
+
+- `ClipboardSyncLoopbackAuth.java` — dropped `FALLBACK_TOKEN`, `fallbackToken()`, and `FALLBACK_PROOF_FIELD`.
+- `ClipboardSyncWebPortal.java` — `isLoopbackIngressAuthorized()` now only accepts the real token; removed the `fallbackLoopbackProofForStatusRequest()` path that exposed a fallback-token HMAC proof in `/status` too.
+- `ClipboardSyncLoopbackIngressClient.java` — removed the wrapper `fallbackLoopbackIngressToken()` and the corresponding fallback-proof check in `verifyExpectedPortal()`.
+- `GboardWebClipboardCaptureBootstrap.java` — this was the one legit caller of the fallback (used if `loopbackIngressToken` came back null/empty from prefs). Since `WebClipboardPreferences.ensureDefaults()` always generates a random token on first run, that null case should basically never happen in practice — so instead of falling back to a guessable value, it now just reports the capture bridge as unavailable and bails out safely.
+
+Net effect: `/phone-clipboard` and the loopback proof on `/status` now only trust the actual per-install random token, nothing static.
+
+Didn't touch the pairing-code compare (`isAuthorized()`) or add rate limiting — wanted to keep this PR scoped to the one concrete bypass rather than bundle in the other minor stuff I mentioned in the issue. Happy to do those as a separate PR if you'd want them.
+
+Patch is attached / diff below, only touches the four files above, no test files reference the removed symbols so nothing else should need updating.

--- a/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/webclipboard/ClipboardSyncLoopbackAuth.java
+++ b/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/webclipboard/ClipboardSyncLoopbackAuth.java
@@ -9,9 +9,6 @@ import javax.crypto.spec.SecretKeySpec;
 final class ClipboardSyncLoopbackAuth {
     static final String CHALLENGE_QUERY = "loopbackChallenge";
     static final String PROOF_FIELD = "loopbackProof";
-    static final String FALLBACK_PROOF_FIELD = "loopbackFallbackProof";
-    private static final String FALLBACK_TOKEN =
-            "gboardpatches-web-clipboard-loopback-fallback-v1";
     private static final String HMAC_ALGORITHM = "HmacSHA256";
     private static final int MAX_CHALLENGE_LENGTH = 128;
 
@@ -39,10 +36,6 @@ final class ClipboardSyncLoopbackAuth {
         return MessageDigest.isEqual(
                 expectedProof.getBytes(StandardCharsets.UTF_8),
                 suppliedProof.getBytes(StandardCharsets.UTF_8));
-    }
-
-    static String fallbackToken() {
-        return FALLBACK_TOKEN;
     }
 
     private static boolean hasUsableToken(String token) {

--- a/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/webclipboard/ClipboardSyncLoopbackIngressClient.java
+++ b/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/webclipboard/ClipboardSyncLoopbackIngressClient.java
@@ -31,10 +31,6 @@ public final class ClipboardSyncLoopbackIngressClient {
         return isExpectedPortal(port, loopbackIngressToken, DEFAULT_TIMEOUT_MS);
     }
 
-    public static String fallbackLoopbackIngressToken() {
-        return ClipboardSyncLoopbackAuth.fallbackToken();
-    }
-
     public static boolean isExpectedPortal(int port, String loopbackIngressToken, int timeoutMs) {
         String safeToken = loopbackIngressToken == null ? "" : loopbackIngressToken;
         if (safeToken.isEmpty()
@@ -124,11 +120,7 @@ public final class ClipboardSyncLoopbackIngressClient {
             return ClipboardSyncLoopbackAuth.proofMatches(
                     loopbackIngressToken,
                     challenge,
-                    payload.optString(ClipboardSyncLoopbackAuth.PROOF_FIELD, ""))
-                    || ClipboardSyncLoopbackAuth.proofMatches(
-                            loopbackIngressToken,
-                            challenge,
-                            payload.optString(ClipboardSyncLoopbackAuth.FALLBACK_PROOF_FIELD, ""));
+                    payload.optString(ClipboardSyncLoopbackAuth.PROOF_FIELD, ""));
         } catch (Throwable ignored) {
             return false;
         }

--- a/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/webclipboard/ClipboardSyncWebPortal.java
+++ b/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/webclipboard/ClipboardSyncWebPortal.java
@@ -723,11 +723,7 @@ public final class ClipboardSyncWebPortal {
         if (suppliedToken.isBlank()) {
             suppliedToken = extractField(request == null ? "" : request.body, "token");
         }
-        if (constantTimeEquals(expectedToken, suppliedToken)) {
-            return true;
-        }
-        return !expectedToken.isEmpty()
-                && constantTimeEquals(ClipboardSyncLoopbackAuth.fallbackToken(), suppliedToken);
+        return constantTimeEquals(expectedToken, suppliedToken);
     }
 
     private boolean constantTimeEquals(String expected, String supplied) {
@@ -867,13 +863,6 @@ public final class ClipboardSyncWebPortal {
                 if (!loopbackProof.isEmpty()) {
                     payload.put(ClipboardSyncLoopbackAuth.PROOF_FIELD, loopbackProof);
                 }
-                String fallbackLoopbackProof = fallbackLoopbackProofForStatusRequest(
-                        request,
-                        socket);
-                if (!fallbackLoopbackProof.isEmpty()) {
-                    payload.put(ClipboardSyncLoopbackAuth.FALLBACK_PROOF_FIELD,
-                            fallbackLoopbackProof);
-                }
             } catch (Throwable ignored) {
                 return "{\"ok\":false,\"pairingRequired\":true,\"pairingVerified\":false,\"codeLength\":4,\"clients\":[]}";
             }
@@ -888,20 +877,6 @@ public final class ClipboardSyncWebPortal {
         }
         return ClipboardSyncLoopbackAuth.proof(
                 securityConfig.loopbackIngressToken,
-                request.query(ClipboardSyncLoopbackAuth.CHALLENGE_QUERY));
-    }
-
-    private String fallbackLoopbackProofForStatusRequest(Request request, Socket socket) {
-        if (securityConfig.loopbackIngressToken == null
-                || securityConfig.loopbackIngressToken.isEmpty()) {
-            return "";
-        }
-        if (request == null || socket == null || socket.getInetAddress() == null
-                || !socket.getInetAddress().isLoopbackAddress()) {
-            return "";
-        }
-        return ClipboardSyncLoopbackAuth.proof(
-                ClipboardSyncLoopbackAuth.fallbackToken(),
                 request.query(ClipboardSyncLoopbackAuth.CHALLENGE_QUERY));
     }
 

--- a/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/webclipboard/GboardWebClipboardCaptureBootstrap.java
+++ b/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/webclipboard/GboardWebClipboardCaptureBootstrap.java
@@ -167,8 +167,7 @@ public final class GboardWebClipboardCaptureBootstrap {
             String loopbackIngressToken =
                     WebClipboardPreferences.getLoopbackIngressToken(preferences);
             if (loopbackIngressToken == null || loopbackIngressToken.isEmpty()) {
-                loopbackIngressToken =
-                        ClipboardSyncLoopbackIngressClient.fallbackLoopbackIngressToken();
+                return RuntimeLookup.unavailable();
             }
             return RuntimeLookup.available(new RuntimeConfig(
                     WebClipboardPreferences.readPort(preferences),


### PR DESCRIPTION
Follow-up to the issue I opened — figured a PR would save you a round trip, feel free to close/redo if you want it done differently.

This removes `FALLBACK_TOKEN` from `ClipboardSyncLoopbackAuth` and everywhere it was accepted as a stand-in for the real per-install random loopback token. Right now `isLoopbackIngressAuthorized()` in `ClipboardSyncWebPortal` treats the hardcoded string `"gboardpatches-web-clipboard-loopback-fallback-v1"` as valid auth for `POST /phone-clipboard`, which is also the one endpoint that skips the pairing-code check for loopback callers. Since that string is sitting in the public repo (and just as easy to pull out of the built APK), any other app on the device can hit `127.0.0.1:<port>/phone-clipboard` with that header and get treated as a trusted local client, no matter what the actual random token is. Loopback sockets aren't permission-gated on Android so this doesn't take anything beyond normal INTERNET access to pull off.

What changed:

- `ClipboardSyncLoopbackAuth.java` — dropped `FALLBACK_TOKEN`, `fallbackToken()`, and `FALLBACK_PROOF_FIELD`.
- `ClipboardSyncWebPortal.java` — `isLoopbackIngressAuthorized()` now only accepts the real token; removed the `fallbackLoopbackProofForStatusRequest()` path that exposed a fallback-token HMAC proof in `/status` too.
- `ClipboardSyncLoopbackIngressClient.java` — removed the wrapper `fallbackLoopbackIngressToken()` and the corresponding fallback-proof check in `verifyExpectedPortal()`.
- `GboardWebClipboardCaptureBootstrap.java` — this was the one legit caller of the fallback (used if `loopbackIngressToken` came back null/empty from prefs). Since `WebClipboardPreferences.ensureDefaults()` always generates a random token on first run, that null case should basically never happen in practice — so instead of falling back to a guessable value, it now just reports the capture bridge as unavailable and bails out safely.

Net effect: `/phone-clipboard` and the loopback proof on `/status` now only trust the actual per-install random token, nothing static.

Didn't touch the pairing-code compare (`isAuthorized()`) or add rate limiting — wanted to keep this PR scoped to the one concrete bypass rather than bundle in the other minor stuff I mentioned in the issue. Happy to do those as a separate PR if you'd want them.

Patch is attached / diff below, only touches the four files above, no test files reference the removed symbols so nothing else should need updating.
