### PR TITLE
fix: remove hard-coded patch counts from tests

### DIFF
--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardAiWritingToolsPatchRegistrySourceTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardAiWritingToolsPatchRegistrySourceTest.kt
@@ -81,7 +81,6 @@ class GboardAiWritingToolsPatchRegistrySourceTest {
     fun aiWritingToolsInventoryAndActiveSourcesHaveNoRetiredFallbackContracts() {
         val repositoryRoot = Path.of("..").toAbsolutePath().normalize()
         val patches = generatedPublishedPatches()
-        assertEquals(37, patches.size)
         val writingTools = patches.single { patch ->
             patch.get("name").asString == "AI Writing Tools"
         }

--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardCompatibilitySourceTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardCompatibilitySourceTest.kt
@@ -28,7 +28,7 @@ class GboardCompatibilitySourceTest {
     }
 
     @Test
-    fun allThirtyFivePublishedPatchesUseTheSharedCompatibility() {
+    fun allPublishedPatchesUseTheSharedCompatibility() {
         val registry = readSource(REGISTRY_PATH)
         val activeRegistry = registry.replace(Regex("(?s)/\\*.*?\\*/"), "")
         val publicPatchBlocks = activeRegistry.split("@Suppress(\"unused\")")
@@ -37,7 +37,6 @@ class GboardCompatibilitySourceTest {
                     .containsMatchIn(block)
             }
 
-        assertEquals(37, publicPatchBlocks.size)
         publicPatchBlocks.forEach { block ->
             assertEquals(
                 1,

--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardDeveloperOptionsGeneratedInventoryTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardDeveloperOptionsGeneratedInventoryTest.kt
@@ -2,19 +2,17 @@ package dev.jason.gboardpatches.patches.gboard.registry
 
 import java.nio.file.Files
 import java.nio.file.Path
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GboardDeveloperOptionsGeneratedInventoryTest {
     @Test
-    fun generatedInventoryContainsThirtyFivePublishedPatchesAndNoRetiredRows() {
+    fun generatedInventoryContainsExpectedPatchesAndNoRetiredRows() {
         val inventory = generatedPublishedInventory()
         val patches = inventory.getAsJsonArray("patches")
         val names = patches.map { it.asJsonObject.get("name").asString }
 
-        assertEquals(37, patches.size())
         RETIRED_PATCH_NAMES.forEach { retiredName ->
             assertFalse("Retired patch must stay absent: $retiredName", names.contains(retiredName))
         }

--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardGrammarCheckerPatchContractTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardGrammarCheckerPatchContractTest.kt
@@ -312,7 +312,6 @@ class GboardGrammarCheckerPatchContractTest {
         }
         val compatiblePackages = grammarPatch.getAsJsonObject("compatiblePackages")
 
-        assertEquals(37, patches.size)
         assertTrue(grammarPatch.get("use").asBoolean)
         assertEquals(setOf(GBOARD_PACKAGE), compatiblePackages.keySet())
         assertEquals(

--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardInlineSuggestionsPatchContractTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardInlineSuggestionsPatchContractTest.kt
@@ -180,7 +180,6 @@ class GboardInlineSuggestionsPatchContractTest {
         }
         val compatiblePackages = inlinePatch.getAsJsonObject("compatiblePackages")
 
-        assertEquals(37, patches.size)
         assertTrue(inlinePatch.get("use").asBoolean)
         assertEquals(setOf(GBOARD_PACKAGE), compatiblePackages.keySet())
         assertEquals(

--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardLatinGlobePatchContractTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardLatinGlobePatchContractTest.kt
@@ -51,9 +51,8 @@ class GboardLatinGlobePatchContractTest {
     }
 
     @Test
-    fun generatedInventoryContainsThirtySevenRowsAndExactlyOneLatinGlobe() {
+    fun generatedInventoryContainsExactlyOneLatinGlobe() {
         val patches = generatedPublishedPatches()
-        assertEquals(37, patches.size)
         val rows = patches.filter { row ->
             row.get("name").asString == "Latin Globe Key Ignore Interval"
         }

--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardPackageRenamePatchContractTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardPackageRenamePatchContractTest.kt
@@ -49,10 +49,9 @@ class GboardPackageRenamePatchContractTest {
     }
 
     @Test
-    fun `active inventory stays thirty seven with package rename exactly once`() {
+    fun `active inventory contains package rename exactly once`() {
         val patches = generatedPublishedPatches()
 
-        assertEquals(37, patches.size)
         val rows = patches.filter { row -> row.get("name").asString == "Package Rename" }
         assertEquals(1, rows.size)
         val row = rows.single()

--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardPortProductCatalogContractTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardPortProductCatalogContractTest.kt
@@ -65,9 +65,14 @@ class GboardPortProductCatalogContractTest {
             features.map { feature -> feature["feature_id"].asString }.sorted(),
             features.map { feature -> feature["feature_id"].asString },
         )
-        assertEquals(37, features.size)
-        assertEquals(37, features.map { it["feature_id"].asString }.distinct().size)
-        assertEquals(37, features.map { it["public_patch_name"].asString }.distinct().size)
+        assertEquals(
+            features.size,
+            features.map { it["feature_id"].asString }.distinct().size,
+        )
+        assertEquals(
+            features.size,
+            features.map { it["public_patch_name"].asString }.distinct().size,
+        )
 
         val expectedDigest = Files.readString(
             repositoryRoot().resolve(DIGEST_PATH),

--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardPublishedPatchCatalogContractTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardPublishedPatchCatalogContractTest.kt
@@ -12,8 +12,10 @@ class GboardPublishedPatchCatalogContractTest {
     fun catalogExposesEachPublishedMorpheRegistrationExactlyOnce() {
         val registrations = GboardPublishedPatchCatalog.morpheRegistrations
 
-        assertEquals(37, registrations.size)
-        assertEquals(37, registrations.map { patch -> patch.name }.distinct().size)
+        assertEquals(
+            registrations.size,
+            registrations.map { patch -> patch.name }.distinct().size,
+        )
         assertSame(
             gboardInlineSuggestionsFlagPatch,
             registrations.single { patch -> patch.name == "Inline Suggestions" },
@@ -64,7 +66,6 @@ class GboardPublishedPatchCatalogContractTest {
     fun catalogUsesOnlyTheGeneratedTargetAdmission() {
         val patches = generatedPublishedPatches()
 
-        assertEquals(37, patches.size)
         assertEquals(
             setOf(GboardTargetAdmission.packageName),
             patches.flatMap { patch ->

--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardSettingsHomepagePatchContractTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardSettingsHomepagePatchContractTest.kt
@@ -37,13 +37,12 @@ class GboardSettingsHomepagePatchContractTest {
     }
 
     @Test
-    fun generatedInventoryStaysThirtySevenWithSettingsOnceAndTargetOnlyCompatibility() {
+    fun generatedInventoryContainsSettingsOnceWithTargetOnlyCompatibility() {
         val patchesList = generatedPublishedPatches()
         val settings = patchesList.filter {
             it.get("name").asString == "Settings Homepage Override"
         }
 
-        assertEquals(37, patchesList.size)
         assertEquals(1, settings.size)
         assertEquals(true, settings.single().get("use").asBoolean)
         assertEquals(

--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardSignatureBypassPatchContractTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardSignatureBypassPatchContractTest.kt
@@ -35,7 +35,6 @@ class GboardSignatureBypassPatchContractTest {
         )
 
         val patches = generatedPublishedPatches()
-        assertEquals(37, patches.size)
         val signatureRows = patches.filter { row ->
             row.get("name").asString == "Add Gboard Signature Bypass"
         }

--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardStagedReleasePatchContractTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardStagedReleasePatchContractTest.kt
@@ -15,7 +15,6 @@ class GboardStagedReleasePatchContractTest {
         val activeRegistry = registry.replace(Regex("(?s)/\\*.*?\\*/"), "")
         val names = generatedPublishedPatches().map { patch -> patch.get("name").asString }
 
-        assertEquals(37, names.size)
         PUBLISHED_PATCHES.forEach { published ->
             assertTrue(registry.contains("val ${published.declaration} = gboardPublicResourcePatch("))
             assertTrue(activeRegistry.contains("val ${published.declaration} = gboardPublicResourcePatch("))

--- a/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardWebClipboardPatchRegistrySourceTest.kt
+++ b/patches/src/test/kotlin/dev/jason/gboardpatches/patches/gboard/registry/GboardWebClipboardPatchRegistrySourceTest.kt
@@ -53,9 +53,8 @@ class GboardWebClipboardPatchRegistrySourceTest {
     }
 
     @Test
-    fun generatedInventoryHasThirtySevenRowsAndExactlyOneWebClipboard() {
+    fun generatedInventoryHasExactlyOneWebClipboard() {
         val patches = generatedPublishedPatches()
-        assertEquals(37, patches.size)
 
         val rows = patches.filter { it.get("name").asString == "Web Clipboard" }
         assertEquals(1, rows.size)


### PR DESCRIPTION
Removes assertions that hard-code the total number of published Gboard patches.

Adding or removing a patch previously required updating several unrelated tests.

Also removes stale patch counts from test names.