### PR TITLE
feat(extension): implement Backup & Restore for patch, Gboard App settings and flags

### DIFF
--- a/extensions/extension/build.gradle.kts
+++ b/extensions/extension/build.gradle.kts
@@ -93,8 +93,10 @@ android {
 }
 
 dependencies {
+    implementation(libs.gson)
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.robolectric:robolectric:4.14.1")
+    testImplementation("androidx.test:core:1.6.1")
 }
 
 val generateQuickJsNativePayload = tasks.register("generateQuickJsNativePayload") {

--- a/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/settings/GboardBackupSettings.java
+++ b/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/settings/GboardBackupSettings.java
@@ -1,0 +1,154 @@
+package dev.jason.gboardpatches.extension.settings;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.util.Log;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.File;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public final class GboardBackupSettings {
+    private static final String TAG = "GboardPatches";
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private GboardBackupSettings() {
+    }
+
+    public static String exportSettings(Context context) {
+        Map<String, Map<String, Map<String, Object>>> allFiles = new HashMap<>();
+
+        // CE storage
+        scanPrefs(context, allFiles, "ce");
+
+        // DE storage (API 24+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            scanPrefs(context.createDeviceProtectedStorageContext(), allFiles, "de");
+        }
+
+        return GSON.toJson(allFiles);
+    }
+
+    private static void scanPrefs(Context context,
+            Map<String, Map<String, Map<String, Object>>> allFiles, String suffix) {
+        File dataDir = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+                ? context.getDataDir()
+                : new File(context.getApplicationInfo().dataDir);
+        File prefsDir = new File(dataDir, "shared_prefs");
+
+        if (prefsDir.exists() && prefsDir.isDirectory()) {
+            File[] files = prefsDir.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    if (file.isFile() && file.getName().endsWith(".xml")) {
+                        String prefName = file.getName().substring(0, file.getName().length() - 4);
+                        SharedPreferences prefs = context.getSharedPreferences(prefName, Context.MODE_PRIVATE);
+                        Map<String, Map<String, Object>> fileSettings = new HashMap<>();
+                        for (Map.Entry<String, ?> entry : prefs.getAll().entrySet()) {
+                            Object value = entry.getValue();
+                            if (value == null) continue;
+
+                            Map<String, Object> typeValue = new HashMap<>();
+                            String type = "string";
+                            if (value instanceof Boolean) type = "bool";
+                            else if (value instanceof Integer) type = "int";
+                            else if (value instanceof Long) type = "long";
+                            else if (value instanceof Float) type = "float";
+                            else if (value instanceof Set) type = "set";
+
+                            typeValue.put("t", type);
+                            typeValue.put("v", value);
+                            fileSettings.put(entry.getKey(), typeValue);
+                        }
+                        // Use a key that includes the storage type to avoid collisions
+                        allFiles.put(prefName + ":" + suffix, fileSettings);
+                    }
+                }
+            }
+        }
+    }
+
+    public static boolean importSettings(Context context, String json) {
+        try {
+            Type type = new TypeToken<Map<String, Map<String, Map<String, Object>>>>() {}.getType();
+            Map<String, Map<String, Map<String, Object>>> allFiles = GSON.fromJson(json, type);
+            if (allFiles == null) {
+                return false;
+            }
+
+            for (Map.Entry<String, Map<String, Map<String, Object>>> fileEntry : allFiles.entrySet()) {
+                String keyWithSuffix = fileEntry.getKey();
+                String prefName;
+                Context targetContext;
+
+                if (keyWithSuffix.endsWith(":de") && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    prefName = keyWithSuffix.substring(0, keyWithSuffix.length() - 3);
+                    targetContext = context.createDeviceProtectedStorageContext();
+                } else if (keyWithSuffix.endsWith(":ce")) {
+                    prefName = keyWithSuffix.substring(0, keyWithSuffix.length() - 3);
+                    targetContext = context;
+                } else {
+                    // Fallback for old backup files without suffix
+                    prefName = keyWithSuffix;
+                    targetContext = context;
+                }
+
+                SharedPreferences prefs = targetContext.getSharedPreferences(prefName, Context.MODE_PRIVATE);
+                SharedPreferences.Editor editor = prefs.edit();
+                editor.clear();
+
+                Map<String, Map<String, Object>> fileSettings = fileEntry.getValue();
+                for (Map.Entry<String, Map<String, Object>> settingEntry : fileSettings.entrySet()) {
+                    String key = settingEntry.getKey();
+                    Map<String, Object> typeValue = settingEntry.getValue();
+                    String t = (String) typeValue.get("t");
+                    Object v = typeValue.get("v");
+
+                    if (t == null || v == null) continue;
+
+                    switch (t) {
+                        case "bool":
+                            editor.putBoolean(key, (Boolean) v);
+                            break;
+                        case "int":
+                            editor.putInt(key, ((Number) v).intValue());
+                            break;
+                        case "long":
+                            editor.putLong(key, ((Number) v).longValue());
+                            break;
+                        case "float":
+                            editor.putFloat(key, ((Number) v).floatValue());
+                            break;
+                        case "string":
+                            editor.putString(key, (String) v);
+                            break;
+                        case "set":
+                            if (v instanceof Iterable) {
+                                HashSet<String> set = new HashSet<>();
+                                for (Object item : (Iterable<?>) v) {
+                                    if (item instanceof String) {
+                                        set.add((String) item);
+                                    }
+                                }
+                                editor.putStringSet(key, set);
+                            }
+                            break;
+                    }
+                }
+                editor.apply();
+            }
+            return true;
+        } catch (Throwable throwable) {
+            Log.w(TAG, "Failed to import settings", throwable);
+            return false;
+        }
+    }
+}

--- a/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/settings/GboardBackupSettingsFeature.java
+++ b/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/settings/GboardBackupSettingsFeature.java
@@ -1,0 +1,105 @@
+package dev.jason.gboardpatches.extension.settings;
+
+import android.content.Context;
+import android.widget.Toast;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import dev.jason.gboardpatches.extension.R;
+
+public final class GboardBackupSettingsFeature
+        implements GboardPatchesSettingsContract.Feature {
+    private static final String EXPORT_FILE_NAME = "gboard_patches_backup.json";
+    private static final String EXPORT_MIME_TYPE = "application/json";
+    private static final String[] IMPORT_MIME_TYPES = {"application/json", "text/plain", "*/*"};
+
+    private final String entryTitle;
+    private final String entrySummary;
+    private final String exportTitle;
+    private final String exportSummary;
+    private final String importTitle;
+    private final String importSummary;
+    private final String exportDoneMessage;
+    private final String importDoneMessage;
+    private final String importFailedMessage;
+
+    public GboardBackupSettingsFeature(Context context) {
+        entryTitle = GboardSettingsText.get(context, R.string.gboard_patches_backup_title);
+        entrySummary = GboardSettingsText.get(context, R.string.gboard_patches_backup_summary);
+        exportTitle = GboardSettingsText.get(context, R.string.gboard_patches_backup_export_title);
+        exportSummary = GboardSettingsText.get(context, R.string.gboard_patches_backup_export_summary);
+        importTitle = GboardSettingsText.get(context, R.string.gboard_patches_backup_import_title);
+        importSummary = GboardSettingsText.get(context, R.string.gboard_patches_backup_import_summary);
+        exportDoneMessage = GboardSettingsText.get(context, R.string.gboard_patches_backup_export_done);
+        importDoneMessage = GboardSettingsText.get(context, R.string.gboard_patches_backup_import_done);
+        importFailedMessage = GboardSettingsText.get(context, R.string.gboard_patches_backup_import_failed);
+    }
+
+    @Override
+    public String getEntryTitle() {
+        return entryTitle;
+    }
+
+    @Override
+    public String getEntrySummary() {
+        return entrySummary;
+    }
+
+    @Override
+    public GboardPatchesSettingsContract.Screen buildScreen(
+            GboardPatchesSettingsContract.FeatureHost host) {
+        return new GboardPatchesSettingsContract.Screen(
+                entryTitle,
+                "Gboard",
+                entryTitle,
+                entrySummary,
+                Collections.emptyList(),
+                Collections.singletonList(new GboardPatchesSettingsContract.Section(
+                        null,
+                        Arrays.asList(
+                                new GboardPatchesSettingsContract.CommandRow(
+                                        exportTitle,
+                                        exportSummary,
+                                        true,
+                                        () -> exportSettings(host)),
+                                new GboardPatchesSettingsContract.CommandRow(
+                                        importTitle,
+                                        importSummary,
+                                        true,
+                                        () -> importSettings(host))
+                        ))),
+                GboardPatchesSettingsContract.RefreshPolicy.none(),
+                GboardPatchesSettingsContract.PanelStyle.FLAT);
+    }
+
+    private void exportSettings(GboardPatchesSettingsContract.FeatureHost host) {
+        if (host == null || host.getContext() == null) {
+            return;
+        }
+        Context context = host.getContext();
+        String json = GboardBackupSettings.exportSettings(context);
+        GboardPatchesSettingsContract.createTextDocument(host,
+                EXPORT_FILE_NAME,
+                EXPORT_MIME_TYPE,
+                json,
+                () -> Toast.makeText(context, exportDoneMessage, Toast.LENGTH_SHORT).show());
+    }
+
+    private void importSettings(GboardPatchesSettingsContract.FeatureHost host) {
+        if (host == null || host.getContext() == null) {
+            return;
+        }
+        Context context = host.getContext();
+        GboardPatchesSettingsContract.openTextDocument(host,
+                IMPORT_MIME_TYPES,
+                json -> {
+                    if (GboardBackupSettings.importSettings(context, json)) {
+                        Toast.makeText(context, importDoneMessage, Toast.LENGTH_LONG).show();
+                        GboardPatchesSettingsContract.refresh(host);
+                    } else {
+                        Toast.makeText(context, importFailedMessage, Toast.LENGTH_SHORT).show();
+                    }
+                });
+    }
+}

--- a/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/settings/GboardPatchesSettingsFeatureRegistry.java
+++ b/extensions/extension/src/main/java/dev/jason/gboardpatches/extension/settings/GboardPatchesSettingsFeatureRegistry.java
@@ -28,6 +28,7 @@ public final class GboardPatchesSettingsFeatureRegistry {
         addIfAvailable(context, features, new GboardKeyboardLayoutSettingsGroupFeature(context));
         addIfAvailable(context, features, new GboardClipboardSettingsFeature());
         addIfAvailable(context, features, new GboardSettingsHomepageSettingsFeature());
+        addIfAvailable(context, features, new GboardBackupSettingsFeature(context));
         addIfAvailable(context, features, new GboardDeveloperOptionsSettingsFeature(context));
         return Collections.unmodifiableList(features);
     }

--- a/extensions/extension/src/main/settings-text/gboard_settings_text.xml
+++ b/extensions/extension/src/main/settings-text/gboard_settings_text.xml
@@ -48,6 +48,42 @@
         <translation locale="en">Open keyboard</translation>
         <translation locale="zh-Hant">打開鍵盤</translation>
     </string>
+    <string name="gboard_patches_backup_title">
+        <translation locale="en">Backup &amp; restore</translation>
+        <translation locale="zh-Hant">備份與還原</translation>
+    </string>
+    <string name="gboard_patches_backup_summary">
+        <translation locale="en">Export or import all settings</translation>
+        <translation locale="zh-Hant">匯出或匯入所有設定</translation>
+    </string>
+    <string name="gboard_patches_backup_export_title">
+        <translation locale="en">Export settings</translation>
+        <translation locale="zh-Hant">匯出設定</translation>
+    </string>
+    <string name="gboard_patches_backup_export_summary">
+        <translation locale="en">Save all current settings to a JSON file</translation>
+        <translation locale="zh-Hant">將所有目前的設定儲存為 JSON 檔案</translation>
+    </string>
+    <string name="gboard_patches_backup_import_title">
+        <translation locale="en">Import settings</translation>
+        <translation locale="zh-Hant">匯入設定</translation>
+    </string>
+    <string name="gboard_patches_backup_import_summary">
+        <translation locale="en">Restore settings from a JSON file</translation>
+        <translation locale="zh-Hant">從 JSON 檔案還原設定</translation>
+    </string>
+    <string name="gboard_patches_backup_export_done">
+        <translation locale="en">Settings exported successfully</translation>
+        <translation locale="zh-Hant">設定匯出成功</translation>
+    </string>
+    <string name="gboard_patches_backup_import_done">
+        <translation locale="en">Settings imported successfully. Please restart Gboard to apply changes.</translation>
+        <translation locale="zh-Hant">設定匯入成功。請重新啟動 Gboard 以套用變更。</translation>
+    </string>
+    <string name="gboard_patches_backup_import_failed">
+        <translation locale="en">Failed to import settings. The file might be invalid.</translation>
+        <translation locale="zh-Hant">匯入設定失敗。檔案可能無效。</translation>
+    </string>
     <string name="gboard_patches_keyboard_preview_title">
         <translation locale="en">Gboard Patches</translation>
         <translation locale="zh-Hant">Gboard Patches</translation>

--- a/extensions/extension/src/test/java/dev/jason/gboardpatches/extension/settings/GboardBackupSettingsTest.java
+++ b/extensions/extension/src/test/java/dev/jason/gboardpatches/extension/settings/GboardBackupSettingsTest.java
@@ -1,0 +1,73 @@
+package dev.jason.gboardpatches.extension.settings;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+@RunWith(RobolectricTestRunner.class)
+public final class GboardBackupSettingsTest {
+    private Context context;
+
+    @Before
+    public void setUp() {
+        context = ApplicationProvider.getApplicationContext();
+    }
+
+    @Test
+    public void exportAndImportRestoresAllTypes() {
+        // Prepare some settings
+        String prefName = "test_prefs";
+        SharedPreferences prefs = context.getSharedPreferences(prefName, Context.MODE_PRIVATE);
+        Set<String> stringSet = new HashSet<>();
+        stringSet.add("item1");
+        stringSet.add("item2");
+
+        prefs.edit()
+                .putString("string_key", "string_value")
+                .putBoolean("bool_key", true)
+                .putInt("int_key", 123)
+                .putLong("long_key", 456L)
+                .putFloat("float_key", 7.89f)
+                .putStringSet("set_key", stringSet)
+                .apply();
+
+        // Export
+        String json = GboardBackupSettings.exportSettings(context);
+        Assert.assertNotNull(json);
+        Assert.assertTrue(json.contains("test_prefs:ce"));
+        Assert.assertTrue(json.contains("\"t\": \"string\""));
+        Assert.assertTrue(json.contains("\"v\": \"string_value\""));
+
+        // Clear and Verify cleared
+        prefs.edit().clear().apply();
+        Assert.assertFalse(prefs.contains("string_key"));
+
+        // Import
+        boolean success = GboardBackupSettings.importSettings(context, json);
+        Assert.assertTrue(success);
+
+        // Verify restored
+        Assert.assertEquals("string_value", prefs.getString("string_key", null));
+        Assert.assertTrue(prefs.getBoolean("bool_key", false));
+        Assert.assertEquals(123, prefs.getInt("int_key", 0));
+        Assert.assertEquals(456L, prefs.getLong("long_key", 0L));
+        Assert.assertEquals(7.89f, prefs.getFloat("float_key", 0f), 0.001f);
+        Assert.assertEquals(stringSet, prefs.getStringSet("set_key", null));
+    }
+
+    @Test
+    public void importWithInvalidJsonReturnsFalse() {
+        Assert.assertFalse(GboardBackupSettings.importSettings(context, "invalid json"));
+    }
+}


### PR DESCRIPTION
- Add logic to export/import all SharedPreferences as a JSON file.
- Support both Credential Encrypted (CE) and Device Protected (DE) storage to ensure all Gboard settings and key shapes are captured.
- Implement Backup & Restore UI with system document picker integration.
- Add localization for English and Traditional Chinese.
- Add unit tests for storage-aware backup serialization and restoration.

### To test using the patch file/apk/import file you can access the files here
https://drive.google.com/drive/folders/1Btvkiywpk4ImJduGrMcgbaz-zAHKFTOg?usp=drive_link


### Reference Screenshot:
<img width="540" height="1188" alt="Screenshot_2026-08-31-01-42-50-39_9f0904f63180c7adbb1276e862e14289" src="https://github.com/user-attachments/assets/dd74af97-3d2f-49ca-9e4e-ebde0f185435" />
